### PR TITLE
Fixing a Java 9 and beyond regression.

### DIFF
--- a/src/haven/FastMesh.java
+++ b/src/haven/FastMesh.java
@@ -59,7 +59,7 @@ public class FastMesh implements Rendered.Instancable, RenderTree.Node, Disposab
 	FillBuffer dst = env.fillbuf(ibuf);
 	ShortBuffer buf = dst.push().asShortBuffer();
 	ShortBuffer tx = indb.duplicate();
-	tx.rewind();
+	((Buffer) tx).rewind();
 	buf.put(tx);
 	return(dst);
     }

--- a/src/haven/Utils.java
+++ b/src/haven/Utils.java
@@ -1248,25 +1248,25 @@ public class Utils {
     public static FloatBuffer bufcp(float[] a) {
 	FloatBuffer b = mkfbuf(a.length);
 	b.put(a);
-	b.rewind();
+	((Buffer)b).rewind();
 	return(b);
     }
     public static ShortBuffer bufcp(short[] a) {
 	ShortBuffer b = mksbuf(a.length);
 	b.put(a);
-	b.rewind();
+	((Buffer)b).rewind();
 	return(b);
     }
     public static FloatBuffer bufcp(FloatBuffer a) {
-	a.rewind();
+	((Buffer)a).rewind();
 	FloatBuffer ret = mkfbuf(a.remaining());
-	ret.put(a).rewind();
+	((Buffer)ret.put(a)).rewind();
 	return(ret);
     }
     public static IntBuffer bufcp(IntBuffer a) {
-	a.rewind();
+	((Buffer)a).rewind();
 	IntBuffer ret = mkibuf(a.remaining());
-	ret.put(a).rewind();
+	((Buffer)ret.put(a)).rewind();
 	return(ret);
     }
     public static ByteBuffer mkbbuf(int n) {
@@ -1317,15 +1317,15 @@ public class Utils {
 	return(ShortBuffer.wrap(new short[n]));
     }
     public static FloatBuffer wbufcp(FloatBuffer a) {
-	a.rewind();
+	((Buffer)a).rewind();
 	FloatBuffer ret = wfbuf(a.remaining());
-	ret.put(a.slice()).rewind();
+	((Buffer)ret.put(a.slice())).rewind();
 	return(ret);
     }
     public static IntBuffer wbufcp(IntBuffer a) {
-	a.rewind();
+	((Buffer)a).rewind();
 	IntBuffer ret = wibuf(a.remaining());
-	ret.put(a.slice()).rewind();
+	((Buffer)ret.put(a.slice())).rewind();
 	return(ret);
     }
 
@@ -1335,7 +1335,7 @@ public class Utils {
 	int sz = buf.capacity();
 	while(sz - buf.position() < req)
 	    sz <<= 1;
-	return(ByteBuffer.allocate(sz).order(buf.order()).put((ByteBuffer)buf.flip()));
+	return(ByteBuffer.allocate(sz).order(buf.order()).put((ByteBuffer)((Buffer)buf).flip()));
     }
 
     public static float[] c2fa(Color c) {

--- a/src/haven/VertexBuf.java
+++ b/src/haven/VertexBuf.java
@@ -158,7 +158,7 @@ public class VertexBuf {
 		throw(new AssertionError());
 	    FloatBuffer dst = bdst.asFloatBuffer();
 	    if(stride == elfmt.size()) {
-		dst.position(offset / 4);
+		((Buffer)dst).position(offset / 4);
 		dst.put(data);
 	    } else if((stride % 4) == 0) {
 		for(int i = 0, o = offset / 4, fs = stride / 4; i < data.capacity(); i += elfmt.nc, o += fs) {
@@ -188,7 +188,7 @@ public class VertexBuf {
 		throw(new AssertionError());
 	    IntBuffer dst = bdst.asIntBuffer();
 	    if(stride == elfmt.size()) {
-		dst.position(offset / 4);
+		((Buffer)dst).position(offset / 4);
 		dst.put(data);
 	    } else if((stride % 4) == 0) {
 		for(int i = 0, o = offset / 4, fs = stride / 4; i < data.capacity(); i += elfmt.nc, o += fs) {

--- a/src/haven/render/gl/BGL.java
+++ b/src/haven/render/gl/BGL.java
@@ -228,11 +228,11 @@ public abstract class BGL {
     public void bglCopyBufferf(final FloatBuffer dst, final int doff, final FloatBuffer src, final int soff, final int len) {
 	add(new Command() {
 		public void run(GL3 gl) {
-		    dst.position(doff);
-		    src.position(soff).limit(len);
+		    ((Buffer)dst).position(doff);
+		    ((Buffer)src).position(soff).limit(len);
 		    dst.put(src);
-		    dst.rewind();
-		    src.rewind().limit(src.capacity());
+		    ((Buffer)dst).rewind();
+		    ((Buffer)src).rewind().limit(src.capacity());
 		}
 	    });
     }
@@ -240,9 +240,9 @@ public abstract class BGL {
     public void bglCopyBufferf(final FloatBuffer dst, final int doff, final float[] src, final int soff, final int len) {
 	add(new Command() {
 		public void run(GL3 gl) {
-		    dst.position(doff);
+		    ((Buffer)dst).position(doff);
 		    dst.put(src, soff, len);
-		    dst.rewind();
+		    ((Buffer)dst).rewind();
 		}
 	    });
     }

--- a/src/haven/render/gl/GLRender.java
+++ b/src/haven/render/gl/GLRender.java
@@ -223,7 +223,7 @@ public class GLRender implements Render, Disposable {
 				    if(data.va.bufs[i].usage == EPHEMERAL)
 					buf.put(((HeapBuffer)bufs[i]).buf);
 				}
-				buf.flip();
+				((Buffer)buf).flip();
 				gl.glBufferData(GL.GL_ARRAY_BUFFER, jdsz, buf, GL3.GL_STREAM_DRAW);
 			    }
 			});
@@ -436,7 +436,7 @@ public class GLRender implements Render, Disposable {
 		    cgl.glBindBuffer(GL3.GL_PIXEL_PACK_BUFFER, 0);
 		    pbo.dispose();
 		    GLException.checkfor(cgl, env);
-		    data.rewind();
+		    ((Buffer)data).rewind();
 		    /* XXX: It's not particularly nice to do the
 		     * flipping on the dispatch thread, but OpenGL
 		     * does not seem to offer any GPU-assisted
@@ -486,7 +486,7 @@ public class GLRender implements Render, Disposable {
 		    cgl.glBindBuffer(GL3.GL_PIXEL_PACK_BUFFER, 0);
 		    pbo.dispose();
 		    GLException.checkfor(cgl, env);
-		    data.rewind();
+		    ((Buffer)data).rewind();
 		    /* XXX: It's not particularly nice to do the
 		     * flipping on the dispatch thread, but OpenGL
 		     * does not seem to offer any GPU-assisted

--- a/src/haven/render/gl/StreamBuffer.java
+++ b/src/haven/render/gl/StreamBuffer.java
@@ -63,7 +63,7 @@ public class StreamBuffer implements haven.Disposable {
 		if(!used[i]) {
 		    if(xfbufs[i] == null)
 			xfbufs[i] = mkbuf();
-		    xfbufs[i].rewind();
+		    ((Buffer)xfbufs[i]).rewind();
 		    used[i] = true;
 		    return(xfbufs[i]);
 		}
@@ -120,7 +120,7 @@ public class StreamBuffer implements haven.Disposable {
 	    synchronized(this) {
 		ByteBuffer ret = this.data;
 		this.data = null;
-		ret.rewind();
+		((Buffer)ret).rewind();
 		return(ret);
 	    }
 	}


### PR DESCRIPTION
If you compile using Java 9 or later (I am compiling using Java 11 locally) the application fails due to a change in Java 9 involving the method return types of various ByteBuffer implementations. See apache/felix#114 for details. This impacts a handful of methods and files, which I've updated as a cherry-pickable commit.