### PR TITLE
Display Curio real time progress

### DIFF
--- a/src/haven/GItem.java
+++ b/src/haven/GItem.java
@@ -46,6 +46,7 @@ public class GItem extends AWidget implements ItemInfo.SpriteOwner, GSprite.Owne
     public boolean matches = false;
     public boolean sendttupdate = false;
     private long filtered = 0;
+    public double studytime = 0;
 
     public static void setFilter(ItemFilter filter) {
 	GItem.filter = filter;

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -40,7 +40,6 @@ import rx.functions.Action1;
 import rx.functions.Action3;
 
 import static haven.Inventory.sqsz;
-import static haven.Text.*;
 
 public class WItem extends Widget implements DTarget2 {
     public static final Resource missing = Resource.local().loadwait("gfx/invobjs/missing");

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -39,6 +39,7 @@ import rx.functions.Action1;
 import rx.functions.Action3;
 
 import static haven.Inventory.sqsz;
+import static haven.Text.*;
 
 public class WItem extends Widget implements DTarget2 {
     public static final Resource missing = Resource.local().loadwait("gfx/invobjs/missing");
@@ -288,6 +289,15 @@ public class WItem extends Widget implements DTarget2 {
 		g.aimage(tex, sz.div(2), 0.5, 0.5);
 		tex.dispose();
 	    } else {
+		GItem itm = WItem.this.item;
+		if (itm.studytime > 0 && meter > 0) {
+		    int timeleft = (int) (itm.studytime * (1.0 - meter));
+		    int hoursleft = timeleft / 60;
+		    int minutesleft = timeleft - hoursleft * 60;
+		    Tex tex = Text.renderstroked(String.format("%d:%02d", hoursleft, minutesleft)).tex();
+		    g.aimage(tex, TEXT_PADD_BOT.add(sz), 1, 1);
+		    tex.dispose();
+		}
 		g.chcolor(255, 255, 255, 64);
 		Coord half = sz.div(2);
 		g.prect(half, half.inv(), half, meter * Math.PI * 2);

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -35,6 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.awt.image.BufferedImage;
 import haven.ItemInfo.AttrCache;
+import me.ender.timer.Timer;
 import rx.functions.Action1;
 import rx.functions.Action3;
 
@@ -291,7 +292,8 @@ public class WItem extends Widget implements DTarget2 {
 	    } else {
 		GItem itm = WItem.this.item;
 		if (itm.studytime > 0 && meter > 0) {
-		    int timeleft = (int) (itm.studytime * (1.0 - meter));
+		    double studytime = CFG.REAL_TIME_CURIO.get() ? itm.studytime / Timer.SERVER_RATIO : itm.studytime;
+		    int timeleft = (int) (studytime * (1.0 - meter));
 		    int hoursleft = timeleft / 60;
 		    int minutesleft = timeleft - hoursleft * 60;
 		    Tex tex = Text.renderstroked(String.format("%d:%02d", hoursleft, minutesleft)).tex();

--- a/src/haven/resutil/Curiosity.java
+++ b/src/haven/resutil/Curiosity.java
@@ -44,6 +44,8 @@ public class Curiosity extends ItemInfo.Tip {
 	this.enc = enc;
 	this.time = time;
 	this.lph = (exp > 0 && time > 0) ? (3600 * exp / time) : 0;
+	if (owner instanceof GItem)
+	    ((GItem) owner).studytime = (CFG.REAL_TIME_CURIO.get() ? time / Timer.SERVER_RATIO : time) / 60;
     }
 
     static String[] units = {"s", "m", "h", "d"};

--- a/src/haven/resutil/Curiosity.java
+++ b/src/haven/resutil/Curiosity.java
@@ -45,7 +45,7 @@ public class Curiosity extends ItemInfo.Tip {
 	this.time = time;
 	this.lph = (exp > 0 && time > 0) ? (3600 * exp / time) : 0;
 	if (owner instanceof GItem)
-	    ((GItem) owner).studytime = (CFG.REAL_TIME_CURIO.get() ? time / Timer.SERVER_RATIO : time) / 60;
+	    ((GItem) owner).studytime = time / 60d;
     }
 
     static String[] units = {"s", "m", "h", "d"};


### PR DESCRIPTION
Displaying real time progress of curios.
Two issues:

1. Can't tell if we're dealing with a curio that's being studied or a curio that is used in some other fashion. Might cause confusion. _Not really sure if there are cases where a curio can also be used in a way that displays a meter other than studying it._
2. Ideally this should override PROGRESS_NUMBER config so that curios always display remaining time. I thought the graphic was still nice to have.