### PR TITLE
Mapping client re-initialization

### DIFF
--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -317,13 +317,14 @@ public class Config {
     }
     
     public static void initAutomapper(UI ui) {
-	if(!MappingClient.initialized()) {
-	    MappingClient.init(ui.sess.glob);
-	    MappingClient automapper = MappingClient.getInstance();
-	    automapper.SetPlayerName(playername);
-	    automapper.SetEndpoint(CFG.AUTOMAP_ENDPOINT.get());
-	    automapper.EnableGridUploads(CFG.AUTOMAP_UPLOAD.get());
-	    automapper.EnableTracking(CFG.AUTOMAP_TRACK.get());
+        if (MappingClient.initialized()) {
+            MappingClient.destroy();
 	}
+	MappingClient.init(ui.sess.glob);
+	MappingClient automapper = MappingClient.getInstance();
+	automapper.SetPlayerName(playername);
+	automapper.SetEndpoint(CFG.AUTOMAP_ENDPOINT.get());
+	automapper.EnableGridUploads(CFG.AUTOMAP_UPLOAD.get());
+	automapper.EnableTracking(CFG.AUTOMAP_TRACK.get());
     }
 }

--- a/src/integrations/mapv4/MappingClient.java
+++ b/src/integrations/mapv4/MappingClient.java
@@ -49,8 +49,8 @@ public class MappingClient {
     public static void destroy() {
 	synchronized (MappingClient.class) {
 	    if(INSTANCE != null) {
-	        INSTANCE.gridsUploader.shutdownNow();
-	        INSTANCE.scheduler.shutdownNow();
+	        INSTANCE.gridsUploader.shutdown();
+	        INSTANCE.scheduler.shutdown();
 		INSTANCE = null;
 	    }
 	}

--- a/src/integrations/mapv4/MappingClient.java
+++ b/src/integrations/mapv4/MappingClient.java
@@ -46,6 +46,16 @@ public class MappingClient {
 	}
     }
     
+    public static void destroy() {
+	synchronized (MappingClient.class) {
+	    if(INSTANCE != null) {
+	        INSTANCE.gridsUploader.shutdownNow();
+	        INSTANCE.scheduler.shutdownNow();
+		INSTANCE = null;
+	    }
+	}
+    }
+    
     public static boolean initialized() {return INSTANCE != null;}
     
     public static MappingClient getInstance() {


### PR DESCRIPTION
Destroy mapping client on character select if it's already initialized to avoid bug where relogging / changing character kept using the old character data and was bugging out.
Not big into Java so might not be the most optimal approach but seems to work

Fixes #31 