### PR TITLE
Enable option to "Always show long tooltips" when hovering an item.

### DIFF
--- a/src/haven/CFG.java
+++ b/src/haven/CFG.java
@@ -56,6 +56,7 @@ public class CFG<T> {
     public static final CFG<Boolean> MMAP_SHOW_BIOMES = new CFG<>("ui.mmap_biomes", true);
     public static final CFG<Boolean> MMAP_SHOW_PATH = new CFG<>("ui.mmap_path", false);
     public static final CFG<Boolean> MMAP_SHOW_MARKER_NAMES = new CFG<>("ui.mmap_mnames", false);
+    public static final CFG<Boolean> UI_ALWAYS_SHOW_LONG_TOOLTIPS = new CFG<>("ui.items_long_tooltips", false);
     public static final CFG<Boolean> MENU_SINGLE_CTRL_CLICK = new CFG<>("ui.menu_single_ctrl_click", true);
     public static final CFG<UI.KeyMod> MENU_SKIP_AUTO_CHOOSE = new CFG<>("ui.menu_skip_auto_choose", UI.KeyMod.SHIFT);
     public static final CFG<Boolean> MENU_ADD_PICK_ALL = new CFG<>("ui.menu_add_pick_all", false);

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -1075,6 +1075,10 @@ public class OptWnd extends WindowX {
     
 	y += STEP;
 	panel.add(new CFGBox("Show queued path on minimap", CFG.MMAP_SHOW_PATH), x, y);
+	
+	//custom options
+	y += STEP;
+	panel.add(new CFGBox("Always show long tooltips", CFG.UI_ALWAYS_SHOW_LONG_TOOLTIPS), x, y);
     
 	//second row
 	my = Math.max(my, y);

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -134,14 +134,21 @@ public class WItem extends Widget implements DTarget2 {
 		shorttip = longtip = null;
 		ttinfo = info;
 	    }
-	    if(now - hoverstart < 1.0) {
-		if(shorttip == null)
-		    shorttip = new ShortTip(info);
-		return(shorttip);
-	    } else {
+	    
+	    if(CFG.UI_ALWAYS_SHOW_LONG_TOOLTIPS.get()){
 		if(longtip == null)
 		    longtip = new LongTip(info);
 		return(longtip);
+	    } else { /* normal behaviour */
+		if(now - hoverstart < 1.0) {
+		    if(shorttip == null)
+			shorttip = new ShortTip(info);
+		    return(shorttip);
+		} else {
+		    if(longtip == null)
+			longtip = new LongTip(info);
+		    return(longtip);
+		}
 	    }
 	} catch(Loading e) {
 	    return("...");


### PR DESCRIPTION
I did this change because I hate how I have to wait to have full information when I'm hovering my mouse over items. It's a small change but people might find it usefull...

Regards,