### PR TITLE
Fixed broken build on fresh environments, blame loftar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,8 +132,8 @@
       <file file="etc/tile_highlight.json"/>
       <fileset dir="." includes="i10n/**/**.json"/>
     </jar>
-    <copy file="lib/builtin-res.jar" todir="build"/>
-    <copy file="lib/hafen-res.jar" todir="build"/>
+    <copy file="lib/ext/builtin-res.jar" todir="build"/>
+    <copy file="lib/ext/hafen-res.jar" todir="build"/>
   </target>
 
   <target name="jar" depends="hafen-client, buildinfo, lib-classes">


### PR DESCRIPTION
external res files were moved from `lib` into `lib/ext` but the reference to them in the build script wasn't changed. I assume no one's dev envs broke because they have an old res file hanging in the `lib` root, but any fresh dev environments will break.