### PR TITLE
9 Add Ubuntu launcher

### DIFF
--- a/Licence.md
+++ b/Licence.md
@@ -1,0 +1,33 @@
+# Haven & Hearth Client -- Copying Rights
+
+This file documents the copying rights of the Haven & Hearth client source tree. The source tree is partitioned into a few sections, each with their own copying restrictions. These partitions and their respective licensing details are as follows:
+
+### `src/haven' Directory
+The files in the `src/haven' directory and its subdirectories are the main source code of the client. It is subject to the GNU Lesser General Public License, version 3, as published by the Free Software Foundation. A copy of this license can be found in the file `doc/LGPL-3' in this source tree. The copyright to all these files is owned by Fredrik Tolf and Björn Johannessen.
+
+### `lib' Directory
+- **lib/ext/jogl/:** These files are part of JOGL, the Java OpenGL implementation. They are co-owned by Sun Microsystems and the JogAmp community, licensed under a BSD license. Please see its homepage, [JogAmp](http://jogamp.org/), for further and current details.
+- **lib/jglob.jar:** This is a simple annotation processor written by Fredrik Tolf, considered to be in the public domain. Source code can be found [here](http://www.dolda2000.com/gitweb/?p=jglob.git).
+- **lib/ext/builtin-res.jar, lib/ext/hafen-res.jar:** These files contain various data files with game content. Their contents are owned by Fredrik Tolf and Björn Johannessen. 
+
+### `src/com/jcraft' Directory
+These files are part of JCraft's open source implementation of the OGG and Vorbis multimedia formats, licensed under the LPGL, version 2.1, and owned by JCraft, Inc. Visit [JCraft](http://www.jcraft.com/jorbis/) for details.
+
+### `src/dolda/xiphutil' Directory
+Files constituting a simple library for using JCraft's Jogg/Jorbis libraries, written by Fredrik Tolf, considered to be in the public domain.
+
+### Other Files
+- `etc/icon.png': Icon used for the main client window, considered our trademark.
+- Majority of other files, including `build.xml', are considered to be in the public domain.
+
+### Build Script
+The `build/hafen.jar' file consists of files compiled from the `src' directory, some resources from the `etc' directory, and the extracted JCraft files. It is primarily LPGL and a little bit public domain.
+
+### Additional Notes
+The Git repository may contain copies of game resources in historical versions (before `hafen-res.jar'). They are subject to terms similar to `lib/ext/hafen-res.jar'. If you decide to publish a historical version containing these resources, you must add a notice that they are owned by Fredrik Tolf and Björn Johannessen.
+
+If you make changes to incorporate new files or licenses, update this file accordingly. For incorporating changes into the mainline client, copyright ownership transfer is required (see README for details).
+
+---
+
+*Authored by Fredrik Tolf. Last updated on 2021-08-29.*

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,0 +1,70 @@
+[![forthebadge cc-by](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by/4.0)
+## Project Title
+Hafen-Client, the new Haven client
+
+### Languages Used
+JAVA, json
+-------------
+
+### Project Description
+Hafen-Client, the new Haven client with many settings and fixes, created by @EnderWiggin (Andrii Gook) & @dolda2000 (Fredrik Tolf). This client is used to connect to the server for the Haven & Hearth online game and play said game.
+
+-------------
+### Credits, Contributors, Organizations
+#### List of contributors: 
+@EnderWiggin (Andrii Gook), @dolda2000 (Fredrik Tolf), @tomventura (Tom Ventura), @elsid (Roman Siromakha), @k-t (Marat Vildanov), @ghandhikus (Daniel Debert), @Fr-Dae (Kervern Anthony), @surculus12, @jamesblack (James Black), @qbalukom (Jakub Łukomski), @stachowski, @ProgrammerDan (Daniel Boston), @romovs (Roman Ovseitsev)
+
+#### License: License.md
+
+-------------
+### Project Goal / Target Audience
+Changes so far:
+
+- Option to save minimap
+- Option to always show kin names
+- Option to hide flavor objects
+- Changed title font to more readable one
+- Mass transfer for inventories (CTRL+ALT+Click drops all similar items, SHIFT+ALT+Click transfers all similar items)
+- Mass transfer for stockpiles (SHIFT+Click or CTRL+Click to put/remove single item, hold ALT to move all)
+- Zoom in/out camera with numpad +/-
+- Quick access for hand slots near portrait
+- Increased chat font size and added timestamps to chat messages
+- Improved behavior and fixes related to certain in-game actions like smelting, crafting, and tool tooltips
+- Added various radar icons for different in-game elements
+- Updated display options for terrain, inventory, and other game elements
+- Improved UI elements, including combat info, tooltips, and highlighting broken items
+- Tweaked and fixed various crashes, menu behaviors, and UI enhancements
+	
+-------------
+### Installation
+In order to compile the source tree into a useful executable, the Apache Ant build system is needed. Running `ant` reads the `build.xml' file in the root directory of the source tree and performs the actions described by it to produce the executable output. 
+
+The main external dependencies of the source tree are having a local Java Development Kit (JDK) installed and (as mentioned above) the Apache Ant build system. On a Debian-based Linux system, these can usually be installed via the `default-jdk' and `ant' packages. For other distributions or operating systems, please use local documentation or your own faculties.
+
+#### Windows
+make a new folder "haven" and download the jar ![here](https://enderwiggin.github.io/hafen/launcher-hafen.jar) 
+
+#### Ubuntu
+Open a terminal and copy paste this lign.
+```properties
+sudo apt update && sudo apt install default-jre -y && mkdir -p ~/Game/Haven/ && cd ~/Game/Haven/ && wget https://enderwiggin.github.io/hafen/launcher-hafen.jar -O launcher-hafen.jar && chmod -R 775 ./ && exit
+```
+**Make a launcher with icon**
+```properties
+cp ~/Game/Haven/Haven-ender.desktop ~/.local/share/applications/
+```
+It *should* be in application menu => Game
+
+-------------
+### Usage
+This client is used to connect to the server for the Haven & Hearth online game and play said game. For details regarding the game itself, please refer to its main website at <http://www.havenandhearth.com/>.
+
+-------------
+### update
+automatic update nothing to do
+
+-------------
+### How to Contribute
+If you want me to accept back any changes that you might have made into the public client available from the website, the one main rule that we wish to enforce is that we want you to sign over ownership of the code you wish to contribute to us. More detailed information about contributing to the project is available in the README file.
+
+More detailed information about the technical aspects and contributing to the project is available in the README file. 

--- a/src/Debian/Haven-ender.desktop
+++ b/src/Debian/Haven-ender.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Haven-hearth
+Comment=try survive in haven and hearth world, good luck!
+Icon=./Games/Haven/cache/https/game.havenandhearth.com/java/icon.gif
+Exec=bash ./Games/Haven/haven-ender.sh
+Path=./Games/Haven/
+Actions=
+Categories=Game;

--- a/src/Debian/haven-ender.sh
+++ b/src/Debian/haven-ender.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd ~/Games/Haven/Work
+java -jar ./launcher-hafen.jar && exit


### PR DESCRIPTION
https://github.com/Fr-Dae/hafen-client/issues/9
https://github.com/EnderWiggin/hafen-client/issues/94

- Creation of standard markdown (md) files to comply with github display standards. (readme with model, licence)

- I created a Debian folder in /src containing a sh script and a launcher shortcut for the desktop (tested and working). 

- (I don't know how) it is imperative that the `/src/Debian/Haven-ender.desktop` and `/src/Debian/Haven-ender.sh` files are placed at the root of the game (where the jar and config sound files are) otherwise the script **will not work.**. 

- I recommend deleting old txt files that have become useless.

fix too https://github.com/EnderWiggin/hafen-client/issues/63