### PR TITLE
Allow Birchbark Kuksa to be selected by Refill Drinks macro

### DIFF
--- a/src/auto/InvHelper.java
+++ b/src/auto/InvHelper.java
@@ -42,7 +42,7 @@ public class InvHelper {
     
     static boolean isDrinkContainer(WItem item) {
 	String resname = item.item.resname();
-	return resname.endsWith("/waterskin") || resname.endsWith("/waterflask") || resname.endsWith("/glassjug");
+	return resname.endsWith("/waterskin") || resname.endsWith("/waterflask") || resname.endsWith("/glassjug") || resname.endsWith("/kuksa");
     }
     
     static boolean isNotFull(ContainedItem item) {


### PR DESCRIPTION
This is a simple change to allow refilling drinks. I've tested this on the hafen run configuration.