### PR TITLE
Allow refilling drinks from barrels when "Show Info" is disabled

### DIFF
--- a/src/haven/GobTag.java
+++ b/src/haven/GobTag.java
@@ -288,7 +288,7 @@ public enum GobTag {
                 tags.add(SPEED);
             }
             
-            if("Water".equals(gob.contents())) {
+            if(name.equals("gfx/terobjs/barrel") && barrelHasWater(gob)) {
                 tags.add(HAS_WATER);
             }
             
@@ -351,6 +351,11 @@ public enum GobTag {
         }
     
         return tags;
+    }
+    
+    private static boolean barrelHasWater(Gob gob) {
+        return gob.ols.stream()
+            .anyMatch(o -> o.name().equals("gfx/terobjs/barrel-water"));
     }
     
     private static boolean isDrying(String ol) {


### PR DESCRIPTION
This fixes a bug where you can't use the refill drinks automation to refill from a barrel when "Show Info" is disabled.

The refill drinks automation requires the `HAS_WATER` tag to be set on the barrel https://github.com/EnderWiggin/hafen-client/blob/111e0d242a1cbccfe7eb7d282b5a31f5b82299ca/src/auto/Actions.java#L87-L90

However, the tag is currently calculated based off the `contents` text used for "Show Info". When "Show Info" is disabled, that text is never generated and so the barrel never gets the proper tag.

This simplifies the check to look at the overlays, just like the "Show Info" rendering does in here:
https://github.com/EnderWiggin/hafen-client/blob/111e0d242a1cbccfe7eb7d282b5a31f5b82299ca/src/haven/GeneralGobInfo.java#L206-L211

If you'd prefer I add a helper to try to avoid duplication of logic to get barrel contents, I can try that. It's currently just in here and the place I show above.

### Alternatives I Tried

I thought this was preferable to always invoking `GeneralGobInfo.render()` even if "Show Info" is disabled or splitting out the logic to always update `GeneralGobInfo.contents()`.


