### PR TITLE
Check the wisp to prevent uploading the character creation grid

### DIFF
--- a/src/haven/Gob.java
+++ b/src/haven/Gob.java
@@ -768,7 +768,7 @@ public class Gob implements RenderTree.Node, Sprite.Owner, Skeleton.ModOwner, Eq
 	if(m != null)
 	    m.move(c);
 	if(Boolean.TRUE.equals(isMe()) && CFG.AUTOMAP_TRACK.get()) {
-	    MappingClient.getInstance().CheckGridCoord(c);
+	    MappingClient.getInstance().CheckGridCoord(Gob.this, c);
 	    MappingClient.getInstance().Track(id, c);
 	}
 	this.rc = c;

--- a/src/integrations/mapv4/MappingClient.java
+++ b/src/integrations/mapv4/MappingClient.java
@@ -34,6 +34,8 @@ public class MappingClient {
     private int spamCount = 0;
     private Glob glob;
     
+    private boolean checkWisp = true;
+    private boolean isWisp = false;
     public static void init(Glob glob) {
 	synchronized (MappingClient.class) {
 	    if(INSTANCE == null) {
@@ -152,11 +154,29 @@ public class MappingClient {
     
     /***
      * Called as you move around, automatically calculates if you have entered a new grid and calls EnterGrid accordingly.
-     * @param c Normal coordinates
+     * @param gob Player gob, c Normal coordinates
      */
-    public void CheckGridCoord(Coord2d c) {
+    public void CheckGridCoord(Gob gob, Coord2d c) {
 	Coord gc = toGC(c);
 	if(lastGC == null || !gc.equals(lastGC)) {
+	    if (checkWisp) {
+		checkWisp = false;
+		try {
+		    String name = gob.getres().name;
+		    isWisp = name.equals("gfx/borka/wisp");
+		} catch (Exception e) {
+		    checkWisp = true;
+		    return;
+		}
+	    }
+	    if (isWisp) {
+		if (lastGC != null && lastGC.dist(gc) > 5) {
+		    isWisp = false;
+		} else {
+		    lastGC = gc;
+		    return;
+		}
+	    }
 	    EnterGrid(gc);
 	}
     }

--- a/src/integrations/mapv4/MappingClient.java
+++ b/src/integrations/mapv4/MappingClient.java
@@ -166,6 +166,7 @@ public class MappingClient {
 		    isWisp = name.equals("gfx/borka/wisp");
 		} catch (Exception e) {
 		    checkWisp = true;
+		    lastGC = gc;
 		    return;
 		}
 	    }


### PR DESCRIPTION
The Mapper, which is used by many people, recognizes each character creation grid as a new map and requests an upload.
To prevent this, we need to check if a character is in a wisp state