### PR TITLE
Fix "invxf2" transfers leaving behind 1 item per stack

### DIFF
--- a/src/haven/ExtInventory.java
+++ b/src/haven/ExtInventory.java
@@ -575,9 +575,21 @@ public class ExtInventory extends Widget {
 		    item.item.wdgmsg(action, args);
 		}
 	    } else {
+		boolean isInvxf2Transfer = Objects.equals(action, "invxf2");
 		for (WItem item : items) {
 		    if(!item.disposed()) {
-			item.item.wdgmsg(action, args);
+			if (isInvxf2Transfer) {
+			    // bugfix: transfer all in stack at once to avoid stack becoming leftover item
+			    if (item.parent.parent instanceof GItem.ContentsWindow) {
+				args[1] = item.parent.children(WItem.class).size();
+				item.item.wdgmsg(action, args);
+			    } else {
+				args[1] = 1;
+				item.item.wdgmsg(action, args);
+			    }
+			} else {
+			    item.item.wdgmsg(action, args);
+			}
 		    }
 		}
 	    }


### PR DESCRIPTION
Steps to reproduce:
1. open a stockpile
2. take out a stack of 2 or more items
3. open extra info panel and set group to type
4. alt+shift+l click to transfer all

Results:
1 item will be left behind in the stack.

This fixes it by sending the stack size when transferring each item. It only needs to be done once per item in the stack, but I couldn't see an easy way to do it. E.g. see https://github.com/Cediner/ArdClient/pull/104